### PR TITLE
Remove invalid example code and give pointers to chrome.ipcRenderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,14 +6,9 @@
   </head>
   <body>
     <h1>Hello World!</h1>
-    <!-- All of the Node.js APIs are available in this renderer process. -->
-    We are using Node.js <script>document.write(process.versions.node)</script>,
-    Chromium <script>document.write(process.versions.chrome)</script>,
-    and Electron <script>document.write(process.versions.electron)</script>.
+    <p>
+      See the <a href="https://github.com/brave/muon/blob/master/docs/api/ipc-renderer.md">ipcRenderer docs</a> for information on how to communicate with the main process.
+    </p>
   </body>
-
-  <script>
-    // You can also require other files to run in this process
-    require('./renderer.js')
-  </script>
+  <script src="renderer.js"></script>
 </html>

--- a/main.js
+++ b/main.js
@@ -18,8 +18,12 @@ function createWindow () {
     width: 800, height: 600
   })
 
-  // and load the index.html of the app.
+  // and load brave.com
   mainWindow.loadURL('https://www.brave.com')
+
+  // alternatively, uncomment the following line to load index.html via
+  // 'chrome://brave' to expose additional APIs such as 'chrome.ipcRenderer'
+  //mainWindow.loadURL('chrome://brave/' + __dirname + '/index.html');
 
   // Open the DevTools.
   mainWindow.webContents.openDevTools()

--- a/renderer.js
+++ b/renderer.js
@@ -1,3 +1,6 @@
-// This file is required by the index.html file and will
+// This file is loaded by the index.html file and will
 // be executed in the renderer process for that window.
-// All of the Node.js APIs are available in this process.
+// If index.html was loaded via 'chrome://brave', you can
+// talk to the main browser process using chrome.ipcRenderer
+
+console.log(chrome);


### PR DESCRIPTION
Fix comments in main.js and add a (commented out) example showing how to load index.html via `chrome://brave`. Remove erroneous comments and code referencing Node.js APIs from index.html and renderer.js. Add a link to ipcRenderer docs to index.html.

Resolves #2.